### PR TITLE
Improve API Document

### DIFF
--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -14,3 +14,11 @@
 :sectnums!:
 
 :sectnums:
+
+== Introduction
+
+These C intrinsic targets the https://github.com/riscv/riscv-v-spec/tree/master[RISC-V "V" Vector Extension].
+This document states usage and detail of the RVV intrinsics' and its
+programming model. Naming rules and special cases will be covered. Please go to
+link:examples[repository="riscv-non-isa/rvv-intrinsic-doc", branch="master", mode="view", link-window="_blank", server="https://www.github.com/"]
+for more.

--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -22,3 +22,45 @@ This document states usage and detail of the RVV intrinsics' and its
 programming model. Naming rules and special cases will be covered. Please go to
 link:examples[repository="riscv-non-isa/rvv-intrinsic-doc", branch="master", mode="view", link-window="_blank", server="https://www.github.com/"]
 for more.
+
+== Types in RVV C Instrinsic
+
+The RVV C intrinsic are strongly-typed, providing a higher level interface
+than the RVV instructions. The types imply the SEW and LMUL used in
+for the data and can not be implicitly converted.
+
+=== Vector Type
+
+A non-mask vector type encodes the `TYPE` along with `LMUL`. Some fractional
+`LMUL` are not supported for longer element widths. The available vector types
+are listed here.
+
+[cols="1,1,1,1,1,1,1,1"]
+[%autowidth, options="header"]
+|===
+| Types     | LMUL = 1 | LMUL = 2 | LMUL = 4 | LMUL = 8 | LMUL = 1/2 | LMUL = 1/4 | LMUL = 1/8
+| `int64`   | `vint64m1_t`   | `vint64m2_t`   | `vint64m4_t`   | `vint64m8_t`   | N/A             | N/A             | N/A
+| `uint64`  | `vuint64m1_t`  | `vuint64m2_t`  | `vuint64m4_t`  | `vuint64m8_t`  | N/A             | N/A             | N/A
+| `int32`   | `vint32m1_t`   | `vint32m2_t`   | `vint32m4_t`   | `vint32m8_t`   | `vint32mf2_t`   | N/A             | N/A
+| `uint32`  | `vuint32m1_t`  | `vuint32m2_t`  | `vuint32m4_t`  | `vuint32m8_t`  | `vuint32mf2_t`  | N/A             | N/A
+| `int16`   | `vint16m1_t`   | `vint16m2_t`   | `vint16m4_t`   | `vint16m8_t`   | `vint16mf2_t`   | `vint16mf4_t`   | N/A
+| `uint16`  | `vuint16m1_t`  | `vuint16m2_t`  | `vuint16m4_t`  | `vuint16m8_t`  | `vuint16mf2_t`  | `vuint16mf4_t`  | N/A
+| `int8`    | `vint8m1_t`    | `vint8m2_t`    | `vint8m4_t`    | `vint8m8_t`    | `vint8mf2_t`    | `vint8mf4_t`    | `vint8mf8_t`
+| `uint8`   | `vuint8m1_t`   | `vuint8m2_t`   | `vuint8m4_t`   | `vuint8m8_t`   | `vuint8mf2_t`   | `vuint8mf4_t`   | `vuint8mf8_t`
+| `float64` | `vfloat64m1_t` | `vfloat64m2_t` | `vfloat64m4_t` | `vfloat64m8_t` | N/A             | N/A             | N/A
+| `float32` | `vfloat32m1_t` | `vfloat32m2_t` | `vfloat32m4_t` | `vfloat32m8_t` | `vfloat32mf2_t` | N/A             | N/A
+| `float16` | `vfloat16m1_t` | `vfloat16m2_t` | `vfloat16m4_t` | `vfloat16m8_t` | `vfloat16mf2_t` | `vfloat16mf4_t` | N/A
+|===
+
+=== Mask Type
+
+Length of a mask vector value in RVV will never exceed a single vector
+register. The mask vector type encodes the ratio of `SEW` / `LMUL` into the
+types. (N = `SEW` / `LMUL`)
+
+[cols="1,1,1,1,1,1,1,1"]
+[%autowidth, options="header"]
+|===
+| Types | N = 1      | N = 2      | N = 4      | N = 8      | N = 16      | N = 32      | N = 64
+| bool  | `vbool1_t` | `vbool2_t` | `vbool4_t` | `vbool8_t` | `vbool16_t` | `vbool32_t` | `vbool64_t`
+|===

--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -1,0 +1,16 @@
+= RISC-V Vector Extension Intrinsic API Reference Manual
+:doctype: article
+:encoding: utf-8
+:lang: en
+:toc: left
+:numbered:
+:stem: latexmath
+:le: &#8804;
+:ge: &#8805;
+:ne: &#8800;
+:approx: &#8776;
+:inf: &#8734;
+
+:sectnums!:
+
+:sectnums:

--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -64,3 +64,131 @@ types. (N = `SEW` / `LMUL`)
 | Types | N = 1      | N = 2      | N = 4      | N = 8      | N = 16      | N = 32      | N = 64
 | bool  | `vbool1_t` | `vbool2_t` | `vbool4_t` | `vbool8_t` | `vbool16_t` | `vbool32_t` | `vbool64_t`
 |===
+
+== Naming Rules
+
+Intrinsics is the interface to the low level assembly in high level programming
+language. The intrinsic API has the goal to make all the V-ext instructions
+accessible from C/C++. The intrinsic names are as close as the assembly
+mnemonics. Besides the basic intrinsics corresponding to assembly mnemonics,
+there are other intrinsics that do not map to a single instruction in RVV,
+they are named to remain close to the action taken.
+
+The intrinsic names will encode return type if it is appropriate. It is easier
+to know the output type of the intrinsics from the name. In addition, if the
+intrinsic call is used as the operand, having the return type is more immediate.
+If there is no return value, the intrinsics will encode the input value types.
+If the return type is the same, use exceptional rules to differentiate them,
+please refer to section <<naming-exception>>.
+
+```cpp
+INTRINSIC ::= MNEMONIC '_' RET_TYPE
+MNEMONIC ::= Instruction name in v-ext specification, replacing '.' with '_'.
+RET_TYPE ::= SEW LMUL
+SEW ::= ( i8 | i16 | i32 | i64 | u8 | u16 | u32 | u64 | f16 | f32 | f64 )
+LMUL ::= ( m1 | m2 | m4 | m8 | mf2 | mf4 | mf8 )
+
+Example:
+
+vadd.vv vd, vs2, vs1
+vint8m1_t vadd_vv_i8m1(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
+
+vwaddu.vv vd, vs2, vs1
+vint16m2_t vwaddu_vv_i16m2(vint8m1_t vs2, vint8m1_t vs1, size_t vl);
+```
+
+[[naming-exception]]
+=== Exception In Namings
+
+If intrinsics have the same return type under different input types, we can
+not use general naming rules directly on these intrinsics because this will
+cause collision between these intrinsics. Therefore there are exception rules
+for these special cases. The rules are enumerated here.
+
+==== Vector Store Instructions
+
+The return type of the instructions is `void`. So the data type
+stored will be encoded to the intrinsics.
+
+```cpp
+Example:
+
+vse8.v vs3, (rs1)
+void vse8_v_i8m1 (int8_t *base, vint8m1_t value, size_t vl);
+void vse8_v_u8m1 (uint8_t *base, vuint8m1_t value, size_t vl);
+```
+
+==== Vector Comparison Instructions
+
+The instructions return a mask type. So the input type will be encoded to the
+intrinsics.
+
+```cpp
+Example:
+
+vmseq.vv vd, vs2, vs1
+vbool8_t vmseq_vv_i8m1_b8 (vint8m1_t op1, vint8m1_t op2, size_t vl);
+vbool16_t vmseq_vv_i16m1_b16 (vint16m1_t op1, vint16m1_t op2, size_t vl);
+```
+
+==== Vector Reduction Instructions
+
+The instructions' scalar output are held in the 0th element of a single vector
+register using LMUL = 1 in the return vector type. So the input type will be
+encoded in the intrinsics.
+
+```cpp
+Example:
+
+vredsum.vs vd, vs2, vs1
+vint8m1_t vredsum_vs_i8m1_i8m1 (vint8m1_t dest, vint8m1_t vector, vint8m1_t scalar, size_t vl);
+vint8m1_t vredsum_vs_i8m2_i8m1 (vint8m1_t dest, vint8m2_t vector, vint8m1_t scalar, size_t vl);
+```
+
+==== Vector Scalar Move Instructions
+
+The instructions' return a scalar value. So the input type will be encoded in
+the intrinsics.
+
+```cpp
+Example:
+
+vmv.x.s rd, vs2
+int8_t vmv_x_s_i8m1_i8 (vint8m1_t src);
+int8_t vmv_x_s_i8m2_i8 (vint8m2_t src);
+```
+
+==== `vcpop` and `vfirst`
+
+The instructions return a scalar value. So the input type will be encoded in
+the intrinsics.
+
+```cpp
+Example:
+
+vcpop.m rd, vs2
+unsigned long vcpop_m_b1 (vbool1_t op1, size_t vl);
+unsigned long vcpop_m_b2 (vbool2_t op1, size_t vl);
+
+vfirst.m rd, vs2, vm
+long vfirst_m_b1 (vbool1_t op1, size_t vl);
+long vfirst_m_b2 (vbool2_t op1, size_t vl);
+```
+
+==== `vmadc` and `vmsbc`
+
+The instructions return a mask type. So the input type will be encoded to the
+intrinsics.
+
+```cpp
+Example:
+
+vmadc.vv vd, vs2, vs1 
+
+vbool8_t vmadc_vv_i8m1_b8 (vint8m1_t op1, vint8m1_t op2, size_t vl);
+vbool8_t vmadc_vv_i16m2_b8 (vint16m2_t op1, vint16m2_t op2, size_t vl);
+
+vmsbc.vvm vd, vs2, vs1, v0
+vbool8_t vmsbc_vvm_i8m1_b8 (vint8m1_t op1, vint8m1_t op2, vbool8_t borrowin, size_t vl);
+vbool8_t vmsbc_vvm_i16m2_b8 (vint16m2_t op1, vint16m2_t op2, vbool8_t borrowin, size_t vl);
+```

--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -297,3 +297,151 @@ enum RVV_CSR {
 unsigned long vread_csr(enum RVV_CSR csr);
 void vwrite_csr(enum RVV_CSR csr, unsigned long value);
 ```
+
+== Vector Loads and Stores
+
+This chapter corresponds to instructions in https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#7-vector-loads-and-stores[7. Vector Loads and Stores]
+of v-spec. The C intrinsics provide high level interface so the users don't need
+to care about detail addressing mode or encoding.
+
+The file link:intrinsic_funcs/02_vector_loads_and_stores_functions.md[repository="riscv-non-isa/rvv-intrinsic-doc", branch="master", mode="view", link-window="_blank", server="https://www.github.com/"]
+collects prototype of all vector load / store intrinsic functions.
+
+=== Vector Unit-Stride Load / Store Intrinsic Functions
+
+The functions in this section corresponds to https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#74-vector-unit-stride-instructions[7.4. Vector Unit-Stride Instructions]
+in v-spec.
+
+The vector load functions unit-stride load data from the base pointer by the
+vector length provided. The data will be returned by the function.
+
+The vector store function store vector data into the base pointer by the vector
+length provided. The functions don't return anything. Masked unit-stride store
+functions don't have a `maskedoff` argument. When unmasked, no element is
+stored
+
+The intrinsic functions are in the format:
+
+```cpp
+// Vector Unit-Stride Load
+RETURN_VEC_TYPE vle{SEW}_v_{RETURN_VEC_SHORT_TYPE} (SCALAR_TYPE *base, size_t vl);
+RETURN_VEC_TYPE vle{SEW}_v_{RETURN_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, RETURN_VEC_TYPE maskedoff, SCALAR_TYPE *base, size_t vl);
+
+Example:
+vint8m1_t vle8_v_i8m1 (const int8_t *base, size_t vl);
+vint8m1_t vle8_v_i8m1_m (vbool8_t mask, vint8m1_t maskedoff, const int8_t *base, size_t vl);
+
+// Vector Unit-Stride Store
+void vse{SEW}_v_{STORE_VEC_SHORT_TYPE} (SCALAR_TYPE *base, STORE_VEC_TYPE value, size_t vl);
+void vse{SEW}_v_{STORE_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, SCALAR_TYPE *base, STORE_VEC_TYPE value, size_t vl);
+
+Example:
+void vse8_v_i8m1 (int8_t *base, vint8m1_t value, size_t vl);
+void vse8_v_i8m1_m (vbool8_t mask, int8_t *base, vint8m1_t value, size_t vl);
+```
+
+==== Vector Mask Load / Store Intrinsic Functions
+
+The mask load / store functions load / store the masked values into a single
+vector register. They do not have a masked type.
+
+The intrinsic functions are in the format:
+
+```cpp
+// N = SEW / LMUL
+
+// Vector Mask Load
+VEC_BOOL_TYPE vlm_v_b{N} (SCALAR_BOOL_TYPE *base, size_t vl);
+
+Example:
+vbool8_t vlm_v_b8 (const uint8_t *base, size_t vl);
+
+// Vector Mask Store
+void vsm_v_b{N} (SCALAR_BOOL_TYPE *base, VEC_BOOL_TYPE value, size_t vl);
+
+Example: 
+void vsm_v_b8 (uint8_t *base, vbool8_t value, size_t vl);
+```
+
+=== Vector Strided Load / Store Functions
+
+The functions in this section corresponds to https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#75-vector-strided-instructions[7.5. Vector Strided Instructions]
+in v-spec.
+
+An additional `bstride` argument is needed compared to the unit-stride
+functions. The unit of `bstride` is in bytes.
+
+The intrinsic functions are in the format:
+
+```cpp
+// Vector Strided Load
+RETURN_VEC_TYPE vlse{SEW}_v_{RETURN_VEC_SHORT_TYPE} (SCALAR_TYPE *base, ptrdiff_t bstride, size_t vl);
+RETURN_VEC_TYPE vlse{SEW}_v_{RETURN_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, RETURN_VEC_TYPE maskedoff, SCALAR_TYPE *base, ptrdiff_t bstride, size_t vl);
+
+Example:
+vint8m1_t vlse8_v_i8m1 (const int8_t *base, ptrdiff_t bstride, size_t vl);
+vint8m1_t vlse8_v_i8m1_m (vbool8_t mask, vint8m1_t maskedoff, const int8_t *base, ptrdiff_t bstride, size_t vl);
+
+// Vector Strided Store
+void vsse{SEW}_v_{STORE_VEC_SHORT_TYPW} (SCALAR_TYPE *base, ptrdiff_t bstride, STORE_VEC_TYPE value, size_t vl);
+void vsse{SEW}_v_{STORE_VEC_SHORT_TYPW}_m (VEC_BOOL_TYPE mask, SCALAR_TYPE *base, ptrdiff_t bstride, STORE_VEC_TYPE value, size_t vl);
+
+Example:
+void vsse8_v_i8m1 (int8_t *base, ptrdiff_t bstride, vint8m1_t value, size_t vl);
+void vsse8_v_i8m1_m (vbool8_t mask, int8_t *base, ptrdiff_t bstride, vint8m1_t value, size_t vl);
+```
+
+=== Vector Indexed Load / Store Functions
+
+The functions in this section corresponds to https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#76-vector-indexed-instructions[7.6. Vector Indexed Instructions]
+in v-spec.
+
+An additional `bindex` argument is needed compared to the unit-stride
+functions. The SEW encoded in the function name corresponds to the element
+width of the index.
+
+The intrinsic functions are in the format:
+
+```cpp
+// Vector Indexed Load 
+RETURN_VEC_TYPE vloxei{INDEX_SEW}_v_{RETURN_VEC_SHORT_TYPE} (SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, size_t vl);
+RETURN_VEC_TYPE vloxei{INDEX_SEW}_v_{RETURN_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, RETURN_VEC_TYPE maskedoff, SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, size_t vl);
+RETURN_VEC_TYPE vluxei{INDEX_SEW}_v_{RETURN_VEC_SHORT_TYPE} (SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, size_t vl);
+RETURN_VEC_TYPE vluxei{INDEX_SEW}_v_{RETURN_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, RETURN_VEC_TYPE maskedoff, SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, size_t vl);
+
+Example:
+vint32m1_t vloxei8_v_i32m1 (const int32_t *base, vuint8mf4_t bindex, size_t vl);
+vint32m1_t vloxei8_v_i32m1_m (vbool32_t mask, vint32m1_t maskedoff, const int32_t *base, vuint8mf4_t bindex, size_t vl);
+vint32m1_t vluxei8_v_i32m1 (const int32_t *base, vuint8mf4_t bindex, size_t vl);
+vint32m1_t vluxei8_v_i32m1_m (vbool32_t mask, vint32m1_t maskedoff, const int32_t *base, vuint8mf4_t bindex, size_t vl);
+
+// Vector Indexed Store
+void vsoxei{INDEX_SEW}_v_{STORE_VEC_SHORT_TYPE} (SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, STORE_VEC_TYPE value, size_t vl);
+void vsoxei{INDEX_SEW}_v_{STORE_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, STORE_VEC_TYPE value, size_t vl);
+void vsuxei{INDEX_SEW}_v_{STORE_VEC_SHORT_TYPE} (SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, STORE_VEC_TYPE value, size_t vl);
+void vsuxei{INDEX_SEW}_v_{STORE_VEC_SHORT_TYPE}_m (VEC_BOOL_TYPE mask, SCALAR_TYPE *base, INDEX_VEC_TYPE bindex, STORE_VEC_TYPE value, size_t vl);
+
+Example:
+void vsoxei32_v_i32m1 (int32_t *base, vuint32m1_t bindex, vint32m1_t value, size_t vl);
+void vsoxei32_v_i32m1_m (vbool32_t mask, int32_t *base, vuint32m1_t bindex, vint32m1_t value, size_t vl);
+void vsuxei32_v_i32m1 (int32_t *base, vuint32m1_t bindex, vint32m1_t value, size_t vl);
+void vsuxei32_v_i32m1_m (vbool32_t mask, int32_t *base, vuint32m1_t bindex, vint32m1_t value, size_t vl);
+```
+
+=== Vector Unit-stride Fault-Only-First Loads Operations
+
+The functions in this section corresponds to https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#77-unit-stride-fault-only-first-loads[7.7. Unit-stride Fault-Only-First Loads]
+in v-spec.
+
+An additonal `*new_vl` is passed into the function and the number of elements
+loaded will be written into it.
+
+The intrinsic functions are in the format:
+
+```cpp
+RETURN_VEC_TYPE vle{SEW}ff_v_{RETURN_VEC_SHORT_TYPE} (SCALAR_TYPE *base, size_t *new_vl, size_t vl);
+
+Example:
+vint32m1_t vle32ff_v_i32m1 (const int32_t *base, size_t *new_vl, size_t vl);
+```
+

--- a/rvv-intrinsic-api.adoc
+++ b/rvv-intrinsic-api.adoc
@@ -192,3 +192,108 @@ vmsbc.vvm vd, vs2, vs1, v0
 vbool8_t vmsbc_vvm_i8m1_b8 (vint8m1_t op1, vint8m1_t op2, vbool8_t borrowin, size_t vl);
 vbool8_t vmsbc_vvm_i16m2_b8 (vint16m2_t op1, vint16m2_t op2, vbool8_t borrowin, size_t vl);
 ```
+
+== Configuration and Utility Functions
+
+=== Vector Length-Related Functions
+
+This chapter corresponds to configuration instructions `vsetvl`, `vsetvli` and
+`vsetivli`. The following functions is called to obtain vector length and used
+as input parameter for other C intrisic functions that performs actual
+computation. Calling this function won't trigger rvv configuration
+instructions. The configuration instructions will be triggered when `vl` is
+passed as parameters into other C intrinsic API-s.
+
+==== `vsetvlmax`
+
+The functions return the maximum number of elements to process for the later
+vector instruction(s), given the `SEW` and `LMUL`. (VLMAX = VLEN * LMUL / SEW,
+please refer to https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#34-vector-type-register-vtype[v-spec : 3.4. Vector type register, `vtype`].
+
+The intrinsic functions are in the format below, with `e{SEW}m{LMUL}`
+encoding a valid vector type.
+
+```cpp
+size_t vsetvlmax_e{SEW}m{LMUL}();
+
+Example:
+size_t vsetvlmax_e64m1 ();
+```
+
+==== `vsetvl`
+
+The functions return the number of elements to process for the later vector
+instructions, given `SEW`, `LMUL` and `avl` (available vector length).
+
+The intrinsic functions are in the format below, with `e{SEW}m{LMUL}`
+encoding a valid vector type.
+
+```cpp
+size_t vsetvl_e{SEW}m{LMUL}(size_t avl);
+
+Example:
+size_t vsetvlmax_e32m1 ();
+```
+
+=== Reinterpret Cast Conversion Functions
+
+The functions reinterpret the contents of a data as a different type under the
+same SEW/LMUL.
+
+```cpp
+RETURN_VEC_TYPE vreinterpret_v_{INPUT_VEC_SHORT_TYPE}_{RETURN_VEC_SHORT_TYPE} (INPUT_VEC_TYPE src);
+
+Example:
+vfloat16m1_t vreinterpret_v_i16m1_f16m1 (vint16m1_t src);
+```
+
+=== Vector Initialization Functions
+
+The functions returns a placeholding vector type.  The data within the vector
+type is undefined and unpredictable. The only recommended usage for these
+functions is to use them as `maskedoff` operand to trigger the agnostic policy.
+
+```cpp
+RETURN_VEC_TYPE vundefined_{RETURN_VEC_SHORT_TYPE} ();
+
+Example:
+vint32m1_t vundefined_i32m1 ();
+```
+
+NOTE: e.g. `vxor(vundefined(), vundefined())` and `vec a = vundefined(); vec b = vxor(a, a);`
+both don't guarantee result vector with all zeros.
+
+=== Vector LMUL Extension and Truncation Functions
+
+These utility functions help users to truncate or extent current LMUL
+under same SEW regardless of vl, it won't change content of vl register.
+The LMUL extension result of extension part are undefined value.
+
+```cpp
+RETURN_VEC_TYPE vlmul_trunc_v_{INPUT_VEC_SHORT_TYPE}_{RETURN_VEC_SHORT_TYPE} (INPUT_VEC_TYPE op1);
+
+Example:
+vint64m1_t vlmul_trunc_v_i64m2_i64m1 (vint64m2_t op1);
+
+RETURN_VEC_TYPE vlmul_ext_v_{INPUT_VEC_SHORT_TYPE}_{RETURN_VEC_SHORT_TYPE} (INPUT_VEC_TYPE op1);
+
+Example:
+vint64m2_t vlmul_ext_v_i64m1_i64m2 (vint64m1_t op1);
+```
+
+=== Read / Write to vector CSRs
+
+Please refer to v-spec: https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#vector-extension-programmers-model[3. Vector Extension Programmer’s Model]
+for definitions and usages of the CSRs.
+
+```cpp
+enum RVV_CSR {
+  RVV_VSTART = 0,
+  RVV_VXSAT,
+  RVV_VXRM,
+  RVV_VCSR,
+};
+
+unsigned long vread_csr(enum RVV_CSR csr);
+void vwrite_csr(enum RVV_CSR csr, unsigned long value);
+```


### PR DESCRIPTION
This PR aims to clarify some format and way of literature for a better and clearer intrinsic API document. Following PR-s will finish the whole document.

Originally the chapters are designed to match the riscv-v-spec document. It would be better if we can re-organize in a higher level since we are now dealing with programming in C and not assembly instructions. Generally the improvements are on the descriptions and naming rules added to each part of intrinsic functions.
